### PR TITLE
fix: Update Release Workflow Repository URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip install twine
-        python -m twine upload --repository-url https://pypi.pkg.github.com/${{ github.repository }} dist/* --verbose
+        python -m twine upload --repository-url https://pypi.pkg.github.com/${{ github.repository_owner }} dist/* --verbose


### PR DESCRIPTION
Updates twine repository URL to use github.repository_owner to fix 404 error during publishing.