### PR TITLE
release: v0.12.2 - Fix CD Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip install twine
-        python -m twine upload --repository-url https://pypi.pkg.github.com/${{ github.repository }} dist/* --verbose
+        python -m twine upload --repository-url https://pypi.pkg.github.com/${{ github.repository_owner }} dist/* --verbose


### PR DESCRIPTION
Release v0.12.2 includes:\n- Fix for GitHub Packages repository URL in release workflow.\n- Ensures automated publishing works correctly.