### PR TITLE
feat: expose get_by_doi and get_by_title_year on ArticleController (v0.14.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research_domain"
-version = "0.14.3"
+version = "0.14.4"
 description = "Library for managing research data: groups, campus, university, researchers, and papers."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/research_domain/controllers/controllers.py
+++ b/src/research_domain/controllers/controllers.py
@@ -296,6 +296,12 @@ class ArticleController(GenericController[Article]):
     def add_author(self, article_id: int, researcher_id: int) -> Optional[Article]:
         return self._service.add_author(article_id, researcher_id)
 
+    def get_by_doi(self, doi: str) -> Optional[Article]:
+        return self._service.find_by_doi(doi)
+
+    def get_by_title_year(self, title: str, year: int) -> Optional[Article]:
+        return self._service.find_by_title_year(title, year)
+
 
 class ProfessionalActivityController(GenericController[ProfessionalActivity]):
     """

--- a/src/research_domain/domain/repositories/repositories.py
+++ b/src/research_domain/domain/repositories/repositories.py
@@ -85,6 +85,12 @@ class ArticleRepositoryInterface(GenericRepositoryInterface):
         """
         ...
 
+    def find_by_title_year(self, title: str, year: int) -> Optional[Article]:
+        """
+        Find an article by exact title and year.
+        """
+        ...
+
 
 class ProfessionalActivityRepositoryInterface(GenericRepositoryInterface):
     """

--- a/src/research_domain/infrastructure/repositories/article_repository_impl.py
+++ b/src/research_domain/infrastructure/repositories/article_repository_impl.py
@@ -16,3 +16,6 @@ class ArticleRepositoryImpl(GenericSqlRepository[Article], IArticleRepository):
         
     def find_by_doi(self, doi: str) -> Optional[Article]:
         return self._session.query(Article).filter(Article.doi == doi).first()
+
+    def find_by_title_year(self, title: str, year: int) -> Optional[Article]:
+        return self._session.query(Article).filter(Article.title == title, Article.year == year).first()

--- a/src/research_domain/infrastructure/repositories/memory_repositories.py
+++ b/src/research_domain/infrastructure/repositories/memory_repositories.py
@@ -107,7 +107,17 @@ class InMemoryAcademicEducationRepository(
 class InMemoryArticleRepository(
     BaseInMemoryRepository, ArticleRepositoryInterface
 ):
-    pass
+    def find_by_doi(self, doi: str):
+        for article in self.get_all():
+            if getattr(article, "doi", None) == doi:
+                return article
+        return None
+
+    def find_by_title_year(self, title: str, year: int):
+        for article in self.get_all():
+            if article.title == title and article.year == year:
+                return article
+        return None
 
 
 class InMemoryProfessionalActivityRepository(

--- a/src/research_domain/infrastructure/repositories/sql_repositories.py
+++ b/src/research_domain/infrastructure/repositories/sql_repositories.py
@@ -119,6 +119,12 @@ class PostgresArticleRepository(
         client = PostgresClient()
         super().__init__(client.get_session(), Article)
 
+    def find_by_doi(self, doi: str):
+        return self._session.query(Article).filter(Article.doi == doi).first()
+
+    def find_by_title_year(self, title: str, year: int):
+        return self._session.query(Article).filter(Article.title == title, Article.year == year).first()
+
 
 class PostgresProfessionalActivityRepository(
     GenericSqlRepository[ProfessionalActivity], ProfessionalActivityRepositoryInterface

--- a/src/research_domain/services/services.py
+++ b/src/research_domain/services/services.py
@@ -374,6 +374,12 @@ class ArticleService(GenericService[Article]):
             return article
         return None
 
+    def find_by_doi(self, doi: str) -> Optional[Article]:
+        return self._repository.find_by_doi(doi)
+
+    def find_by_title_year(self, title: str, year: int) -> Optional[Article]:
+        return self._repository.find_by_title_year(title, year)
+
 
 class ProfessionalActivityService(GenericService[ProfessionalActivity]):
     """


### PR DESCRIPTION
## Summary

- `ArticleRepositoryInterface`: add `find_by_title_year(title, year)`
- `ArticleRepositoryImpl` (SQLite): implement `find_by_title_year`
- `PostgresArticleRepository`: implement `find_by_doi` + `find_by_title_year`
- `InMemoryArticleRepository`: implement `find_by_doi` + `find_by_title_year`
- `ArticleService`: expose `find_by_doi` + `find_by_title_year`
- `ArticleController`: expose `get_by_doi` + `get_by_title_year`
- Version bump: `0.14.3` → `0.14.4`

## Motivation

Callers were forced to use `get_all()` to build a full in-memory lookup
table for deduplication before inserting articles. On large datasets this
causes memory pressure that can crash Python C extensions (segfault exit 139).
Per-article targeted queries eliminate the need to load the whole table.

## Test plan

- [ ] `ArticleController().get_by_doi("10.xxx")` returns correct article or None
- [ ] `ArticleController().get_by_title_year("Title", 2023)` returns correct article or None
- [ ] Existing `create_article` and `add_author` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)